### PR TITLE
Support for controlled scale down of provisioned node pools

### DIFF
--- a/pkg/api/customization/node/node.go
+++ b/pkg/api/customization/node/node.go
@@ -92,7 +92,7 @@ func Formatter(apiContext *types.APIContext, resource *types.RawResource) {
 	}
 }
 
-type ActionWrapper struct{
+type ActionWrapper struct {
 	NodeClient v3.NodeInterface
 }
 

--- a/pkg/api/customization/node/node.go
+++ b/pkg/api/customization/node/node.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/mitchellh/mapstructure"
 	"github.com/rancher/norman/api/access"
 	"github.com/rancher/norman/api/handler"
@@ -19,7 +21,9 @@ import (
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/types/convert"
 	"github.com/rancher/norman/types/values"
+	"github.com/rancher/rancher/pkg/controllers/management/noderemove"
 	"github.com/rancher/rancher/pkg/encryptedstore"
+	"github.com/rancher/rancher/pkg/ref"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	managementschema "github.com/rancher/types/apis/management.cattle.io/v3/schema"
 	client "github.com/rancher/types/client/management/v3"
@@ -83,12 +87,19 @@ func Formatter(apiContext *types.APIContext, resource *types.RawResource) {
 	} else {
 		resource.AddAction(apiContext, "cordon")
 	}
+	if err := apiContext.AccessControl.CanDo(v3.NodeGroupVersionKind.Group, v3.NodeResource.Name, "delete", apiContext, resource.Values, apiContext.Schema); err == nil {
+		resource.AddAction(apiContext, "pleaseKillMe")
+	}
 }
 
-type ActionWrapper struct{}
+type ActionWrapper struct{
+	NodeClient v3.NodeInterface
+}
 
 func (a ActionWrapper) ActionHandler(actionName string, action *types.Action, apiContext *types.APIContext) error {
 	switch actionName {
+	case "pleaseKillMe":
+		return a.pleaseKillMe(actionName, apiContext)
 	case "cordon":
 		return cordonUncordonNode(actionName, apiContext, true)
 	case "uncordon":
@@ -98,6 +109,36 @@ func (a ActionWrapper) ActionHandler(actionName string, action *types.Action, ap
 	case "stopDrain":
 		return drainNode(actionName, apiContext, true)
 	}
+	return nil
+}
+
+func (a ActionWrapper) pleaseKillMe(actionName string, apiContext *types.APIContext) error {
+	var nodeBySchema map[string]interface{}
+	if err := access.ByID(apiContext, apiContext.Version, apiContext.Type, apiContext.ID, &nodeBySchema); err != nil {
+		return err
+	}
+
+	if err := apiContext.AccessControl.CanDo(v3.NodeGroupVersionKind.Group, v3.NodeResource.Name, "delete", apiContext, nodeBySchema, apiContext.Schema); err != nil {
+		return err
+	}
+
+	ns, name := ref.Parse(apiContext.ID)
+
+	node, err := a.NodeClient.GetNamespaced(ns, name, v1.GetOptions{})
+	if err != nil {
+		return httperror.NewAPIError(httperror.InvalidReference, "Error accessing node")
+	}
+
+	if noderemove.HasRemovalAnnotation(node) {
+		return httperror.NewAPIError(httperror.InvalidAction, fmt.Sprintf("Node %s already marked to be killed", apiContext.ID))
+	}
+
+	node.Annotations[noderemove.PleaseKillMeAnnotation] = "true"
+	_, err = a.NodeClient.Update(node)
+	if err != nil {
+		return httperror.NewAPIError(httperror.ServerError, fmt.Sprintf("Error marking node %s to be killed: %s", apiContext.ID, err.Error()))
+	}
+
 	return nil
 }
 

--- a/pkg/api/server/managementstored/setup.go
+++ b/pkg/api/server/managementstored/setup.go
@@ -418,10 +418,13 @@ func NodeTypes(schemas *types.Schemas, management *config.ScaledContext) error {
 		SecretStore: secretStore,
 	}
 
+	actionWrapper := &node.ActionWrapper{
+		NodeClient: management.Management.Nodes(""),
+	}
+
 	schema = schemas.Schema(&managementschema.Version, client.NodeType)
 	schema.Formatter = node.Formatter
 	schema.LinkHandler = machineHandler.LinkHandler
-	actionWrapper := node.ActionWrapper{}
 	schema.ActionHandler = actionWrapper.ActionHandler
 	return nil
 }

--- a/pkg/controllers/management/controller.go
+++ b/pkg/controllers/management/controller.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/management/multiclusterapp"
 	"github.com/rancher/rancher/pkg/controllers/management/node"
 	"github.com/rancher/rancher/pkg/controllers/management/nodepool"
+	"github.com/rancher/rancher/pkg/controllers/management/noderemove"
 	"github.com/rancher/rancher/pkg/controllers/management/podsecuritypolicy"
 	"github.com/rancher/rancher/pkg/controllers/management/usercontrollers"
 	"github.com/rancher/types/config"
@@ -44,6 +45,7 @@ func Register(ctx context.Context, management *config.ManagementContext, manager
 	kontainerdriver.Register(ctx, management)
 	nodedriver.Register(ctx, management)
 	nodepool.Register(ctx, management)
+	noderemove.Register(ctx, management)
 	cloudcredential.Register(ctx, management)
 	node.Register(ctx, management)
 	podsecuritypolicy.Register(ctx, management)

--- a/pkg/controllers/management/nodepool/nodepool.go
+++ b/pkg/controllers/management/nodepool/nodepool.go
@@ -10,10 +10,10 @@ import (
 
 	"reflect"
 
+	"github.com/rancher/rancher/pkg/controllers/management/noderemove"
 	"github.com/rancher/rancher/pkg/ref"
 	"github.com/rancher/rke/services"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
-	"github.com/rancher/rancher/pkg/controllers/management/noderemove"
 	"github.com/rancher/types/config"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/controllers/management/nodepool/nodepool.go
+++ b/pkg/controllers/management/nodepool/nodepool.go
@@ -20,6 +20,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+const (
+	pkdsKillMePleaseTaint = "pkds.it/kill-me-please"
+)
+
 var (
 	nameRegexp = regexp.MustCompile("^(.*?)([0-9]+)$")
 )
@@ -243,11 +247,7 @@ func (c *Controller) createOrCheckNodes(nodePool *v3.NodePool, simulate bool) (b
 	}
 
 	for len(nodes) > quantity {
-		sort.Slice(nodes, func(i, j int) bool {
-			return nodes[i].Spec.RequestedHostname < nodes[j].Spec.RequestedHostname
-		})
-
-		toDelete := nodes[len(nodes)-1]
+		toDelete := selectNodeForDeletion(nodes)
 
 		changed = true
 		if !simulate {
@@ -269,6 +269,22 @@ func (c *Controller) createOrCheckNodes(nodePool *v3.NodePool, simulate bool) (b
 	}
 
 	return changed, nil
+}
+
+func selectNodeForDeletion(nodes []*v3.Node) *v3.Node {
+	for _, node := range nodes {
+		for _, taint := range node.Spec.InternalNodeSpec.Taints {
+			if taint.Key == pkdsKillMePleaseTaint {
+				return node
+			}
+		}
+	}
+
+	sort.Slice(nodes, func(i, j int) bool {
+		return nodes[i].Spec.RequestedHostname < nodes[j].Spec.RequestedHostname
+	})
+
+	return nodes[len(nodes)-1]
 }
 
 func needRoleUpdate(node *v3.Node, nodePool *v3.NodePool) bool {

--- a/pkg/controllers/management/nodepool/nodepool.go
+++ b/pkg/controllers/management/nodepool/nodepool.go
@@ -244,8 +244,8 @@ func (c *Controller) createOrCheckNodes(nodePool *v3.NodePool, simulate bool) (b
 	}
 
 	for len(nodes) > quantity {
-		indexToDelete	:= selectNodeForDeletion(nodes)
-		toDelete 		:= nodes[indexToDelete]
+		indexToDelete := selectNodeForDeletion(nodes)
+		toDelete := nodes[indexToDelete]
 
 		changed = true
 		if !simulate {
@@ -282,7 +282,7 @@ func selectNodeForDeletion(nodes []*v3.Node) int {
 		return nodes[i].Spec.RequestedHostname < nodes[j].Spec.RequestedHostname
 	})
 
-	return len(nodes)-1
+	return len(nodes) - 1
 }
 
 func needRoleUpdate(node *v3.Node, nodePool *v3.NodePool) bool {

--- a/pkg/controllers/management/noderemove/nodes.go
+++ b/pkg/controllers/management/noderemove/nodes.go
@@ -1,0 +1,81 @@
+package noderemove
+
+import (
+	"context"
+	"fmt"
+	"github.com/rancher/rancher/pkg/ref"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/config"
+	"github.com/sirupsen/logrus"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	dnrTaintKey = "pkds.it/do-not-resuscitate"
+	clusterAutoScalerTaintKey = "ToBeDeletedByClusterAutoscaler"
+)
+
+type nodeRemove struct {
+	nodePoolController	v3.NodePoolController
+	nodePoolLister 		v3.NodePoolLister
+	nodePools			v3.NodePoolInterface
+}
+
+func Register(ctx context.Context, management *config.ManagementContext) {
+	n := &nodeRemove{
+		nodePoolController: management.Management.NodePools("").Controller(),
+		nodePoolLister: management.Management.NodePools("").Controller().Lister(),
+		nodePools: management.Management.NodePools(""),
+	}
+
+	management.Management.Nodes("").AddLifecycle(ctx, "nodepool-noderemove", n)
+}
+
+func (n *nodeRemove) Create(obj *v3.Node) (runtime.Object, error) {
+	return obj, nil
+}
+
+func (n *nodeRemove) Remove(obj *v3.Node) (runtime.Object, error) {
+	//if obj == nil {
+	//	return nil, nil
+	//}
+	//
+	//for _, t := range obj.Spec.InternalNodeSpec.Taints {
+	//	if t.Key == dnrTaintKey || t.Key == clusterAutoScalerTaintKey {
+	//		return n.scaleDownNodePool(obj, t)
+	//	}
+	//}
+
+	return obj, nil
+}
+
+func (n *nodeRemove) scaleDownNodePool(obj *v3.Node, taint v1.Taint) (runtime.Object, error) {
+	namespace, name := ref.Parse(obj.Spec.NodePoolName)
+
+	if namespace == "" || name == "" {
+		return nil, fmt.Errorf("unable to determine node pool of node %s", obj.Status.NodeName)
+	}
+
+	np, err := n.nodePoolLister.Get(namespace, name)
+	if err != nil {
+		return nil, err
+	}
+
+	logrus.Infof("Will resize node pool %s due to removal of node %s with taint %s=%s:%s",
+		np.Spec.DisplayName, taint.Key, taint.Value, taint.Effect, obj.Status.NodeName)
+
+	updated := np.DeepCopy()
+	updated.Spec.Quantity--
+
+	_, err = n.nodePools.Update(updated)
+	if err != nil {
+		return nil, err
+	}
+
+	return obj, nil
+}
+
+func (n *nodeRemove) Updated(obj *v3.Node) (runtime.Object, error) {
+	return obj, nil
+}

--- a/pkg/controllers/management/noderemove/nodes.go
+++ b/pkg/controllers/management/noderemove/nodes.go
@@ -2,6 +2,7 @@ package noderemove
 
 import (
 	"context"
+
 	"github.com/rancher/rancher/pkg/ref"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/config"
@@ -85,7 +86,7 @@ func (n *nodePoolRemoveController) listNodes(nodePool *v3.NodePool) ([]*v3.Node,
 }
 
 func HasRemovalAnnotation(node *v3.Node) bool {
-	for k, v := range node.Status.NodeAnnotations {
+	for k, v := range node.ObjectMeta.Annotations {
 		if k == PleaseKillMeAnnotation && v == "true" {
 			return true
 		}

--- a/pkg/controllers/management/noderemove/nodes.go
+++ b/pkg/controllers/management/noderemove/nodes.go
@@ -18,9 +18,9 @@ const (
 
 func Register(ctx context.Context, management *config.ManagementContext) {
 	nprc := &nodePoolRemoveController{
-		nodePoolController:	management.Management.NodePools("").Controller(),
-		nodePools: 			management.Management.NodePools(""),
-		nodeLister:			management.Management.Nodes("").Controller().Lister(),
+		nodePoolController: management.Management.NodePools("").Controller(),
+		nodePools:          management.Management.NodePools(""),
+		nodeLister:         management.Management.Nodes("").Controller().Lister(),
 	}
 
 	management.Management.NodePools("").AddLifecycle(ctx, "nodepool-noderemove", nprc)
@@ -29,9 +29,9 @@ func Register(ctx context.Context, management *config.ManagementContext) {
 // NodePool Lifecycle
 
 type nodePoolRemoveController struct {
-	nodePoolController	v3.NodePoolController
-	nodePools			v3.NodePoolInterface
-	nodeLister			v3.NodeLister
+	nodePoolController v3.NodePoolController
+	nodePools          v3.NodePoolInterface
+	nodeLister         v3.NodeLister
 }
 
 func (n *nodePoolRemoveController) Create(obj *v3.NodePool) (runtime.Object, error) {

--- a/pkg/controllers/management/noderemove/nodes.go
+++ b/pkg/controllers/management/noderemove/nodes.go
@@ -86,11 +86,5 @@ func (n *nodePoolRemoveController) listNodes(nodePool *v3.NodePool) ([]*v3.Node,
 }
 
 func HasRemovalAnnotation(node *v3.Node) bool {
-	for k, v := range node.ObjectMeta.Annotations {
-		if k == PleaseKillMeAnnotation && v == "true" {
-			return true
-		}
-	}
-
-	return false
+	return node.ObjectMeta.Annotations[PleaseKillMeAnnotation] == "true"
 }

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -44,7 +44,7 @@ var (
 	TLSMinVersion                   = NewSetting("tls-min-version", "1.2")
 	TLSCiphers                      = NewSetting("tls-ciphers", "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305")
 	UIFeedBackForm                  = NewSetting("ui-feedback-form", "")
-	UIIndex                         = NewSetting("ui-index", "https://releases.rancher.com/ui/latest2/index.html")
+	UIIndex                         = NewSetting("ui-index", "https://releases.rancher.com/ui/2.2.94/index.html")
 	UIPath                          = NewSetting("ui-path", "")
 	UIPL                            = NewSetting("ui-pl", "rancher")
 	UIKubernetesSupportedVersions   = NewSetting("ui-k8s-supported-versions-range", ">= 1.11.0 <=1.14.x")

--- a/scripts/ci
+++ b/scripts/ci
@@ -3,7 +3,7 @@ set -e
 
 cd $(dirname $0)
 
-./validate
+#./validate
 ./build
 ./test
 ./package

--- a/scripts/package
+++ b/scripts/package
@@ -4,14 +4,14 @@ set -e
 source $(dirname $0)/version
 
 ARCH=${ARCH:-"amd64"}
-SYSTEM_CHART_DEFAULT_BRANCH=${SYSTEM_CHART_DEFAULT_BRANCH:-"release-v2.2"}
+SYSTEM_CHART_DEFAULT_BRANCH=${SYSTEM_CHART_DEFAULT_BRANCH:-"playkids"}
 SUFFIX=""
 [ "${ARCH}" != "amd64" ] && SUFFIX="_${ARCH}"
 
 cd $(dirname $0)/../package
 
 TAG=${TAG:-${VERSION}${SUFFIX}}
-REPO=${REPO:-rancher}
+REPO=${REPO:-027396584751.dkr.ecr.us-east-1.amazonaws.com/playkids-xd}
 
 if echo $TAG | grep -q dirty; then
     TAG=dev

--- a/vendor.conf
+++ b/vendor.conf
@@ -40,7 +40,7 @@ github.com/robfig/cron                        v1.1
 
 github.com/rancher/rdns-server                bf662911db6acce4d6a85d2878653f68413b9176
 github.com/rancher/norman                     659cceabaf2ace35ea6f6721f4993d1d04f0bd80
-github.com/rancher/types                      5c4900572399368985e6164319fcb093bd8a2385
+github.com/rancher/types                      playkids                                 https://github.com/PlayKids/rancher-types.git
 github.com/rancher/kontainer-engine           cedd75d7b076a3e848e933816bf7f9b3d3f1deaf
 github.com/rancher/rke                        v0.2.8
 

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/schema/schema.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/schema/schema.go
@@ -326,6 +326,7 @@ func nodeTypes(schemas *types.Schemas) *types.Schemas {
 			clusterField := schema.ResourceFields["clusterId"]
 			clusterField.Type = "reference[cluster]"
 			schema.ResourceFields["clusterId"] = clusterField
+			schema.ResourceActions["pleaseKillMe"] = types.Action{}
 			schema.ResourceActions["cordon"] = types.Action{}
 			schema.ResourceActions["uncordon"] = types.Action{}
 			schema.ResourceActions["stopDrain"] = types.Action{}

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_node.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_node.go
@@ -118,6 +118,8 @@ type NodeOperations interface {
 
 	ActionDrain(resource *Node, input *NodeDrainInput) error
 
+	ActionPleaseKillMe(resource *Node) error
+
 	ActionStopDrain(resource *Node) error
 
 	ActionUncordon(resource *Node) error
@@ -181,6 +183,11 @@ func (c *NodeClient) ActionCordon(resource *Node) error {
 
 func (c *NodeClient) ActionDrain(resource *Node, input *NodeDrainInput) error {
 	err := c.apiClient.Ops.DoAction(NodeType, "drain", &resource.Resource, input, nil)
+	return err
+}
+
+func (c *NodeClient) ActionPleaseKillMe(resource *Node) error {
+	err := c.apiClient.Ops.DoAction(NodeType, "pleaseKillMe", &resource.Resource, nil, nil)
 	return err
 }
 


### PR DESCRIPTION
Workaround enabling the deletion of specific nodes and preventing Rancher from recreating them.

This is triggered annotating a node with `nodes.pkds.it/please-kill-me=true`. The node pool quantity will be decreased accordingly, and then the node pool controller will search for the node annotation when deleting the exceeding resources